### PR TITLE
Enhance card parsing and scoring

### DIFF
--- a/carioca/cards.py
+++ b/carioca/cards.py
@@ -59,3 +59,17 @@ class Card:
     @property
     def value(self) -> int:
         return VALUES[self.rank]
+
+    # Alternate constructors -------------------------------------------------
+    @classmethod
+    def from_str(cls, text: str) -> "Card":
+        """Create card from a short string like ``"7♣"`` or ``"🃏"``."""
+        text = text.strip()
+        if text in {"🃏", JOKER, JOKER.capitalize()}:
+            return cls(JOKER)
+        rank, suit_char = text[:-1].upper(), text[-1]
+        try:
+            suit = Suit(suit_char)
+        except ValueError as exc:  # pragma: no cover - invalid suit
+            raise ValueError(f"Invalid suit: {suit_char}") from exc
+        return cls(rank, suit)

--- a/carioca/hand.py
+++ b/carioca/hand.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-from rich.console import Console
-from rich.table import Table
+try:
+    from rich.console import Console
+    from rich.table import Table
+except ModuleNotFoundError:  # pragma: no cover - rich optional in tests
+    Console = None
+    Table = None
 
 from .cards import Card
 
@@ -21,8 +25,14 @@ class Hand(list[Card]):
         finally:
             self.sort()
 
+    def points(self) -> int:
+        """Total value of all cards in hand."""
+        return sum(c.value for c in self)
+
     # Pretty-print ------------------------------------------------------------
     def show(self, *, title: str | None = None) -> None:  # pragma: no cover
+        if Console is None or Table is None:
+            raise RuntimeError("rich package required for show()")
         table = Table(title=title, show_header=False)
         table.add_row(" ".join(map(str, self)))
         Console().print(table)

--- a/tests/test_hand.py
+++ b/tests/test_hand.py
@@ -1,0 +1,16 @@
+from carioca.cards import Card, Suit
+from carioca.hand import Hand
+
+
+def test_hand_points() -> None:
+    hand = Hand()
+    hand.take(Card("5", Suit.HEARTS))
+    hand.take(Card("A", Suit.CLUBS))
+    hand.take(Card.from_str("🃏"))
+    assert hand.points() == 5 + 20 + 30
+
+
+def test_card_from_str() -> None:
+    card = Card.from_str("Q" + str(Suit.SPADES))
+    assert card.rank == "Q" and card.suit == Suit.SPADES
+    assert Card.from_str("🃏").is_joker


### PR DESCRIPTION
## Summary
- parse cards from text with `Card.from_str`
- support optional `rich` dependency in `Hand.show`
- add `Hand.points` for scoring
- test new helpers

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885832a7ebc83289fda2000db03dc12