### PR TITLE
Add Streamlit web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ poetry install
 poetry run carioca play --players 3
 ```
 
+Launch the Streamlit UI:
+
+```bash
+poetry run streamlit run streamlit_app/app.py
+```
+
 ## Features
 * Full game engine with flexible YAML rules.
 * Rich-styled Typer CLI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ python = "^3.11"
 typer = { version = "^0.12.3", extras = ["all"] }
 rich = "^13.7.1"
 PyYAML = "^6.0"
+streamlit = "^1.35"
+jinja2 = "^3.1"
+pydantic = "^2.7"
+streamlit-lottie = "^0.0.5"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"

--- a/streamlit_app/Dockerfile
+++ b/streamlit_app/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.11-slim
+COPY streamlit_app /app
+RUN pip install -r /app/requirements.txt
+CMD ["streamlit", "run", "/app/app.py", "--server.port", "8501", "--server.address", "0.0.0.0"]

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import streamlit as st
+from streamlit_lottie import st_lottie
+
+from .state import GameState
+from .utils import card_svg
+
+st.set_page_config(page_title="Carioca", page_icon="🃏", layout="wide")
+
+THEME = "dark"
+BASE_COLOR = "#361860"
+ACCENT = "#F1AC4B"
+
+# -------------------------------------------------------------------
+# Sidebar – new game setup
+# -------------------------------------------------------------------
+with st.sidebar:
+    st.header("Nueva partida")
+    players = st.slider("Jugadores", 2, 4, 2, key="players")
+    rounds = st.slider("Rondas", 1, 8, 8, key="rounds")
+    if st.button("Iniciar") or "game" not in st.session_state:
+        st.session_state.game = GameState.new(players, rounds)
+    st.markdown("[Reglas](https://example.com/reglas.pdf)")
+
+# -------------------------------------------------------------------
+# Main Header – title and scoreboard
+# -------------------------------------------------------------------
+if "game" not in st.session_state:
+    st.session_state.game = GameState.new(players, rounds)
+
+game: GameState = st.session_state.game
+
+st.title(f"Carioca – Ronda {game.round.number}")
+score_table = "| Jugador | Puntaje |\n|--------|---------|\n"
+for i, s in enumerate(game.scores):
+    score_table += f"| {i+1} | {s} |\n"
+st.markdown(score_table)
+
+# -------------------------------------------------------------------
+# Board area – player's hand and piles
+# -------------------------------------------------------------------
+col_deck, col_discard = st.columns(2)
+if col_deck.button("Robar mazo", key="draw_deck", help="D", use_container_width=True):
+    game.draw(from_discard=False)
+if col_discard.button(f"Robar pozo ({len(game.round.discard_pile)})", key="draw_discard", help="P", use_container_width=True):
+    game.draw(from_discard=True)
+
+st.subheader("Tu mano")
+selected = st.multiselect(
+    "Selecciona cartas", options=list(range(len(game.hand))), format_func=lambda i: str(game.hand[i]), key="sel_cards"
+)
+cols = st.columns(len(game.hand))
+for i, card in enumerate(game.hand):
+    with cols[i]:
+        st.image(card_svg(card), use_column_width=True)
+
+if st.button("Descartar", key="discard_btn") and selected:
+    game.discard(selected[0])
+    game.next_player()
+    st.session_state.sel_cards = []
+
+if st.button("Formar trío/escala", key="meld_btn") and selected:
+    if game.meld(selected):
+        st.success("Combinación válida")
+    else:
+        st.error("No es trío ni escala")
+    st.session_state.sel_cards = []
+
+# -------------------------------------------------------------------
+# Meld area
+# -------------------------------------------------------------------
+for player, melds in game.melds.items():
+    with st.expander(f"Jugador {player+1}"):
+        for meld in melds:
+            st.markdown(" ".join(f"{c}" for c in meld))
+
+# -------------------------------------------------------------------
+# Footer – log and close round
+# -------------------------------------------------------------------
+if st.button("Cerrar ronda", key="close_btn", help="C"):
+    if game.can_close():
+        game.close_round()
+        st.success("Ronda cerrada")
+        if game.round.number > game.total_rounds:
+            st.balloons()
+            winner = min(range(len(game.scores)), key=lambda i: game.scores[i])
+            st.write(f"Ganador: Jugador {winner+1}")
+    else:
+        st.error("No puedes cerrar aún")

--- a/streamlit_app/docker-compose.yml
+++ b/streamlit_app/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  app:
+    build: .
+    ports:
+      - "8501:8501"

--- a/streamlit_app/requirements.txt
+++ b/streamlit_app/requirements.txt
@@ -1,0 +1,4 @@
+streamlit==1.35.0
+jinja2
+pydantic
+streamlit-lottie

--- a/streamlit_app/state.py
+++ b/streamlit_app/state.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from pydantic import BaseModel
+
+from carioca.cards import Card
+from carioca.hand import Hand
+from carioca.round import Round
+from carioca.melds import is_trio, is_scale
+
+
+class GameState(BaseModel):
+    round: Round
+    current_player: int = 0
+    melds: Dict[int, List[List[Card]]] = {}
+    scores: List[int]
+    total_rounds: int = 8
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    @classmethod
+    def new(cls, players: int, total_rounds: int = 8) -> "GameState":
+        rnd = Round(1)
+        rnd.start(players, cards_each=6)
+        return cls(
+            round=rnd,
+            melds={i: [] for i in range(players)},
+            scores=[0] * players,
+            total_rounds=total_rounds,
+        )
+
+    # Gameplay helpers --------------------------------------------------
+    def draw(self, from_discard: bool = False) -> None:
+        if from_discard:
+            card = self.round.discard_pile.pop()
+        else:
+            card = self.round.draw_pile.draw()
+        self.hand.take(card)
+
+    def discard(self, index: int) -> Card:
+        card = self.hand.discard(index)
+        self.round.discard_pile.append(card)
+        return card
+
+    def next_player(self) -> None:
+        self.current_player = (self.current_player + 1) % len(self.round.hands)
+
+    @property
+    def hand(self) -> Hand:
+        return self.round.hands[self.current_player]
+
+    def meld(self, indices: List[int]) -> bool:
+        cards = [self.hand[i] for i in sorted(indices, reverse=True)]
+        if is_trio(cards) or is_scale(cards):
+            for i in sorted(indices, reverse=True):
+                self.hand.pop(i)
+            self.melds[self.current_player].append(cards)
+            return True
+        return False
+
+    def can_close(self) -> bool:
+        return not self.hand
+
+    def close_round(self) -> None:
+        # Very naive scoring: remaining card values
+        for i, hand in enumerate(self.round.hands):
+            self.scores[i] += sum(c.value for c in hand)
+        self.round = Round(self.round.number + 1)
+        if self.round.number <= self.total_rounds:
+            self.round.start(len(self.scores), cards_each=5 + self.round.number)
+        self.current_player = 0
+        self.melds = {i: [] for i in range(len(self.scores))}

--- a/streamlit_app/templates/card_back.svg
+++ b/streamlit_app/templates/card_back.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="240" viewBox="0 0 160 240" aria-label="Card back">
+  <rect width="160" height="240" rx="12" fill="#361860"/>
+  <text x="80" y="120" font-size="40" fill="#F1AC4B" text-anchor="middle" dominant-baseline="middle">Carioca</text>
+</svg>

--- a/streamlit_app/templates/card_front.svg
+++ b/streamlit_app/templates/card_front.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="240" viewBox="0 0 160 240" aria-label="{{ rank }}{{ suit }} card">
+  <rect width="160" height="240" rx="12" fill="#fff" stroke="#000"/>
+  <text x="80" y="120" font-size="60" text-anchor="middle" dominant-baseline="middle">{{ rank }}{{ suit }}</text>
+</svg>

--- a/streamlit_app/utils.py
+++ b/streamlit_app/utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Optional
+
+try:
+    from jinja2 import Environment, FileSystemLoader
+except ModuleNotFoundError:  # pragma: no cover - allow tests without deps
+    Environment = None  # type: ignore
+    FileSystemLoader = None  # type: ignore
+
+from carioca.cards import Card, JOKER
+
+if Environment:
+    TEMPLATES = Environment(loader=FileSystemLoader(Path(__file__).parent / "templates"))
+else:  # pragma: no cover - tests without jinja2
+    TEMPLATES = None
+
+
+def card_svg(card: Optional[Card] = None, *, back: bool = False) -> str:
+    """Return SVG for card as data URI."""
+    if TEMPLATES is None:
+        # Fallback minimal SVG for tests without Jinja2
+        label = "?" if card is None else f"{card.rank}{card.suit or ''}"
+        svg = f"<svg xmlns='http://www.w3.org/2000/svg' width='160' height='240'><text x='10' y='20'>{label}</text></svg>"
+    else:
+        if back or card is None:
+            tpl = TEMPLATES.get_template("card_back.svg")
+            svg = tpl.render()
+        else:
+            rank = card.rank if card.rank != JOKER else "🃏"
+            suit = card.suit.value if card.suit else ""
+            tpl = TEMPLATES.get_template("card_front.svg")
+            svg = tpl.render(rank=rank, suit=suit)
+    data = base64.b64encode(svg.encode()).decode()
+    return f"data:image/svg+xml;base64,{data}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))

--- a/tests/test_ui_utils.py
+++ b/tests/test_ui_utils.py
@@ -1,0 +1,7 @@
+from streamlit_app.utils import card_svg
+from carioca.cards import Card, Suit
+
+
+def test_card_svg() -> None:
+    svg_data = card_svg(Card("A", Suit.SPADES))
+    assert svg_data.startswith("data:image/svg+xml;base64,")


### PR DESCRIPTION
## Summary
- add Streamlit-based interface in `streamlit_app/`
- declare Streamlit and related deps
- document how to run the UI
- configure tests to import package
- add unit test for card SVG helper
- clean up pycache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688587674d4c8328ab8349237e4930d3