### PR TITLE
Implement clickable card discard

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -70,17 +70,36 @@ if st.session_state.get("clear_sel_cards"):
         st.session_state.sel_cards = []
     st.session_state.clear_sel_cards = False
 
-selected = st.multiselect(
-    "Selecciona cartas", options=list(range(len(game.hand))), format_func=lambda i: str(game.hand[i]), key="sel_cards"
-)
+selected = st.session_state.setdefault("sel_cards", [])
 cols = st.columns(len(game.hand))
 for i, card in enumerate(game.hand):
-    with cols[i]:
-        st.image(card_svg(card), use_column_width=True)
+    btn_key = f"card_{i}"
+    border = f"2px solid {ACCENT}" if i in selected else "1px solid transparent"
+    st.markdown(
+        f"""
+        <style>
+        div[data-testid="stButton"][key="{btn_key}"] > button {{
+            background: url('{card_svg(card)}') no-repeat center center;
+            background-size: contain;
+            height: 240px;
+            width: 100%;
+            padding: 0;
+            border: {border};
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+    if st.button(" ", key=btn_key):
+        if i in selected:
+            selected.remove(i)
+        else:
+            selected.append(i)
+        st.session_state.sel_cards = selected
+        st.experimental_rerun()
 
 if st.button("Descartar", key="discard_btn") and selected:
     game.discard(selected[0])
-    game.next_player()
     st.session_state.clear_sel_cards = True
 
 if st.button("Formar trío/escala", key="meld_btn") and selected:

--- a/streamlit_app/state.py
+++ b/streamlit_app/state.py
@@ -40,8 +40,10 @@ class GameState(BaseModel):
         self.hand.take(card)
 
     def discard(self, index: int) -> Card:
+        """Discard ``hand[index]`` and advance to the next player."""
         card = self.hand.discard(index)
         self.round.discard_pile.append(card)
+        self.next_player()
         return card
 
     def next_player(self) -> None:


### PR DESCRIPTION
## Summary
- make GameState.discard advance to next player
- turn each card into a clickable button image

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885a879b7148328b108f8c8a417ce1a