### PR TITLE
Improve Carioca Streamlit gameplay

### DIFF
--- a/carioca/game.py
+++ b/carioca/game.py
@@ -29,7 +29,17 @@ class Game:
         print(
             f"[bold]Round {self.current_round} started with {self.players} players[/bold]"
         )
-        # TODO: loop over turns, apply full rules.
+        current = 0
+        while all(rnd.hands):
+            hand = rnd.hands[current]
+            hand.take(rnd.draw_pile.draw())
+            rnd.discard_pile.append(hand.discard())
+            if not hand:
+                print(f"Player {current + 1} closed the round!")
+                break
+            current = (current + 1) % self.players
+        for i, hand in enumerate(rnd.hands):
+            self.scores[i] += sum(c.value for c in hand)
         self.current_round += 1
 
     def save(self) -> None:

--- a/streamlit_app/state.py
+++ b/streamlit_app/state.py
@@ -16,6 +16,7 @@ class GameState(BaseModel):
     melds: Dict[int, List[List[Card]]] = {}
     scores: List[int]
     total_rounds: int = 8
+    finished: bool = False
 
     class Config:
         arbitrary_types_allowed = True
@@ -29,6 +30,7 @@ class GameState(BaseModel):
             melds={i: [] for i in range(players)},
             scores=[0] * players,
             total_rounds=total_rounds,
+            finished=False,
         )
 
     # Gameplay helpers --------------------------------------------------
@@ -67,8 +69,12 @@ class GameState(BaseModel):
         # Very naive scoring: remaining card values
         for i, hand in enumerate(self.round.hands):
             self.scores[i] += sum(c.value for c in hand)
-        self.round = Round(self.round.number + 1)
-        if self.round.number <= self.total_rounds:
-            self.round.start(len(self.scores), cards_each=5 + self.round.number)
+        next_num = self.round.number + 1
+        if next_num <= self.total_rounds:
+            self.round = Round(next_num)
+            self.round.start(len(self.scores), cards_each=5 + next_num)
+        else:
+            self.round = Round(next_num)
+            self.finished = True
         self.current_player = 0
         self.melds = {i: [] for i in range(len(self.scores))}

--- a/streamlit_app/utils.py
+++ b/streamlit_app/utils.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 from typing import Optional
+import json
+from urllib.request import urlopen
 
 try:
     from jinja2 import Environment, FileSystemLoader
@@ -35,3 +37,9 @@ def card_svg(card: Optional[Card] = None, *, back: bool = False) -> str:
             svg = tpl.render(rank=rank, suit=suit)
     data = base64.b64encode(svg.encode()).decode()
     return f"data:image/svg+xml;base64,{data}"
+
+
+def load_lottie_url(url: str) -> dict:
+    """Fetch a Lottie animation from a URL."""
+    with urlopen(url) as resp:
+        return json.load(resp)


### PR DESCRIPTION
## Summary
- add `finished` field to `GameState`
- fetch Lottie animations with new `load_lottie_url` helper
- display final scoreboard and animation when the match ends
- make card selection interactive with checkboxes
- implement a simple round loop in the CLI game stub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885a9d13cc08328b818828797948aef