### PR TITLE
Add basic React Streamlit component

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,20 @@ poetry run streamlit run streamlit_app/app.py
 * Docker & GitHub Actions CI.
 
 See `docs/` soon for detailed rules.
+
+## Streamlit Component
+A minimal interactive board is implemented as a Streamlit component.
+
+Build the frontend:
+
+```bash
+cd frontend
+npm install
+npm run build
+```
+
+Run the example app:
+
+```bash
+poetry run streamlit run example_app.py
+```

--- a/example_app.py
+++ b/example_app.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from carioca.gamestate import GameState
+from python.carioca_component import carioca_component
+
+st.set_page_config(page_title="Carioca Component")
+
+if "game" not in st.session_state:
+    st.session_state.game = GameState.new(players=2)
+
+game: GameState = st.session_state.game
+
+state_dict = game.to_dict()
+updated = carioca_component(state_dict, key="carioca")
+
+if updated != state_dict:
+    st.session_state.game = GameState.from_dict(updated)
+    game = st.session_state.game
+
+st.json(game.to_dict())

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Carioca Component</title>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/index.tsx"></script>
+</body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "carioca-component",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint src --max-warnings 0",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@hello-pangea/dnd": "^13.1.0",
+    "framer-motion": "^11.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0",
+    "vitest": "^0.34.0",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react": "^7.32.2",
+    "@testing-library/react": "^14.1.2"
+  },
+  "peerDependencies": {
+    "streamlit-component-lib": "^1.4.0"
+  }
+}

--- a/frontend/src/GameBoard.test.tsx
+++ b/frontend/src/GameBoard.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { GameBoard } from './GameBoard';
+import type { GameState } from './types';
+
+const state: GameState = {
+  players: [{ id: 1, hand: [{ rank: 'A', suit: '♠', id: 'c1' }] }],
+  table_melds: [],
+  discard_top: null,
+  stock_count: 10,
+  current_turn: 0,
+  phase: 'draw',
+};
+
+describe('GameBoard', () => {
+  it('renders hand', () => {
+    const onMove = vi.fn();
+    const { getByRole } = render(<GameBoard state={state} onMove={onMove} />);
+    expect(getByRole('img')).toBeTruthy();
+  });
+});

--- a/frontend/src/GameBoard.tsx
+++ b/frontend/src/GameBoard.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import { Card, GameState, MovePayload } from './types';
+import { useDrag } from './hooks/useDrag';
+
+export interface GameBoardProps {
+  state: GameState;
+  onMove: (payload: MovePayload) => void;
+}
+
+export function GameBoard({ state, onMove }: GameBoardProps) {
+  const { onDragStart, onDragEnd } = useDrag();
+
+  function handleDragEnd(result: any) {
+    onDragEnd();
+    if (!result.destination) return;
+    const cardId = result.draggableId;
+    onMove({
+      type: 'move',
+      data: {
+        card_ids: [cardId],
+        source_zone: result.source.droppableId,
+        target_zone: result.destination.droppableId,
+      },
+    });
+  }
+
+  return (
+    <DragDropContext onDragEnd={handleDragEnd} onDragStart={(e) => onDragStart(e.source)}>
+      <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
+        <Droppable droppableId="player_hand" direction="horizontal">
+          {(provided) => (
+            <div ref={provided.innerRef} {...provided.droppableProps} style={{ display: 'flex' }}>
+              {state.players[0].hand.map((c: Card, idx: number) => (
+                <Draggable draggableId={`${idx}`} index={idx} key={idx}>
+                  {(prov) => (
+                    <img
+                      ref={prov.innerRef}
+                      {...prov.draggableProps}
+                      {...prov.dragHandleProps}
+                      src={`data:image/svg+xml;base64,${btoa(c.rank + (c.suit || ''))}`}
+                      width={40}
+                      height={60}
+                    />
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+        <Droppable droppableId="discard">
+          {(provided) => (
+            <div ref={provided.innerRef} {...provided.droppableProps} style={{ width: 40, height: 60, border: '1px solid black' }}>
+              {state.discard_top && (
+                <img src={`data:image/svg+xml;base64,${btoa(state.discard_top.rank + (state.discard_top.suit || ''))}`} width={40} height={60} />
+              )}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </div>
+    </DragDropContext>
+  );
+}

--- a/frontend/src/hooks/useDrag.ts
+++ b/frontend/src/hooks/useDrag.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+import type { Card } from '../types';
+
+export function useDrag() {
+  const [dragging, setDragging] = useState<Card | null>(null);
+
+  function onDragStart(card: Card) {
+    setDragging(card);
+  }
+
+  function onDragEnd() {
+    setDragging(null);
+  }
+
+  return { dragging, onDragStart, onDragEnd };
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { GameBoard } from './GameBoard';
+import type { GameState, MovePayload } from './types';
+
+declare global {
+  interface Window {
+    Streamlit?: any;
+  }
+}
+
+function mount() {
+  const root = ReactDOM.createRoot(document.getElementById('root')!);
+  const args = window.parent?.Streamlit?.args ?? {};
+  const state: GameState = args.game_state;
+
+  function onMove(payload: MovePayload) {
+    if (window.Streamlit) {
+      window.Streamlit.setComponentValue(payload);
+    }
+  }
+
+  root.render(<GameBoard state={state} onMove={onMove} />);
+}
+
+if (document.readyState !== 'loading') {
+  mount();
+} else {
+  document.addEventListener('DOMContentLoaded', mount);
+}
+
+export default GameBoard;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,0 +1,27 @@
+export interface Card {
+  rank: string;
+  suit: string | null;
+  owner?: number;
+  id?: string;
+}
+
+export type Zone = 'player_hand' | 'table_meld' | 'discard' | 'stock';
+
+export interface Position {
+  x: number;
+  y: number;
+}
+
+export interface GameState {
+  players: { id: number; name?: string; hand: Card[] }[];
+  table_melds: { owner: number; cards: Card[] }[];
+  discard_top: Card | null;
+  stock_count: number;
+  current_turn: number;
+  phase: 'draw' | 'play' | 'end';
+}
+
+export interface MovePayload {
+  type: 'move' | 'draw' | 'discard' | 'lay' | 'end_turn';
+  data: any;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2018",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'build',
+    emptyOutDir: true,
+    lib: {
+      entry: 'src/index.tsx',
+      formats: ['iife'],
+      name: 'CariocaComponent'
+    },
+  },
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
+});

--- a/python/carioca_component/__init__.py
+++ b/python/carioca_component/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from ._component import carioca_component
+
+__all__ = ["carioca_component"]

--- a/python/carioca_component/_component.py
+++ b/python/carioca_component/_component.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - optional in tests
+    import streamlit as st  # type: ignore
+    from streamlit.components.v1 import declare_component
+except ModuleNotFoundError:  # pragma: no cover - allow tests without streamlit
+    st = None  # type: ignore
+    declare_component = lambda *a, **k: lambda **_kwargs: None  # type: ignore
+
+_COMPONENT_NAME = "carioca_component"
+_BUILD_DIR = Path(__file__).parent / ".." / "frontend" / "build"
+
+_carioca_component = declare_component(_COMPONENT_NAME, path=str(_BUILD_DIR))
+
+
+def carioca_component(game_state: dict[str, Any], key: str | None = None) -> dict[str, Any]:
+    """Render the Carioca board and return updated state."""
+    data = _carioca_component(game_state=game_state, key=key)
+    if data is None:
+        return game_state
+    if isinstance(data, str):
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError:
+            pass
+    if isinstance(data, dict):
+        return data
+    return game_state

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,0 +1,7 @@
+from python.carioca_component._component import carioca_component
+
+
+def test_component_roundtrip():
+    data = {"hello": "world"}
+    result = carioca_component(data)
+    assert result == data


### PR DESCRIPTION
## Summary
- create Streamlit component wrapper under `python/`
- add Vite+React frontend with a simple draggable board
- provide example Streamlit app
- document frontend build steps
- add minimal unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885afa30fd88328a1387470f509d3ae