### PR TITLE
Enhance interactivity

### DIFF
--- a/frontend/src/GameBoard.tsx
+++ b/frontend/src/GameBoard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
+import { motion } from 'framer-motion';
 import { Card, GameState, MovePayload } from './types';
 import { useDrag } from './hooks/useDrag';
 
@@ -29,18 +30,36 @@ export function GameBoard({ state, onMove }: GameBoardProps) {
     <DragDropContext onDragEnd={handleDragEnd} onDragStart={(e) => onDragStart(e.source)}>
       <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
         <Droppable droppableId="player_hand" direction="horizontal">
-          {(provided) => (
-            <div ref={provided.innerRef} {...provided.droppableProps} style={{ display: 'flex' }}>
+          {(provided, snapshot) => (
+            <div
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              style={{
+                display: 'flex',
+                background: snapshot.isDraggingOver ? '#f0f0f0' : 'transparent',
+                transition: 'background 0.2s ease',
+              }}
+            >
               {state.players[0].hand.map((c: Card, idx: number) => (
                 <Draggable draggableId={`${idx}`} index={idx} key={idx}>
-                  {(prov) => (
-                    <img
+                  {(prov, snap) => (
+                    <motion.img
                       ref={prov.innerRef}
                       {...prov.draggableProps}
                       {...prov.dragHandleProps}
                       src={`data:image/svg+xml;base64,${btoa(c.rank + (c.suit || ''))}`}
                       width={40}
                       height={60}
+                      animate={{
+                        rotate: snap.isDragging ? 5 : 0,
+                        scale: snap.isDragging ? 1.1 : 1,
+                      }}
+                      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+                      style={{
+                        boxShadow: snap.isDragging
+                          ? '0 4px 8px rgba(0,0,0,0.3)'
+                          : 'none',
+                      }}
                     />
                   )}
                 </Draggable>
@@ -50,10 +69,26 @@ export function GameBoard({ state, onMove }: GameBoardProps) {
           )}
         </Droppable>
         <Droppable droppableId="discard">
-          {(provided) => (
-            <div ref={provided.innerRef} {...provided.droppableProps} style={{ width: 40, height: 60, border: '1px solid black' }}>
+          {(provided, snapshot) => (
+            <div
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              style={{
+                width: 40,
+                height: 60,
+                border: '1px solid black',
+                background: snapshot.isDraggingOver ? '#f0f0f0' : 'transparent',
+                transition: 'background 0.2s ease',
+              }}
+            >
               {state.discard_top && (
-                <img src={`data:image/svg+xml;base64,${btoa(state.discard_top.rank + (state.discard_top.suit || ''))}`} width={40} height={60} />
+                <img
+                  src={`data:image/svg+xml;base64,${btoa(
+                    state.discard_top.rank + (state.discard_top.suit || '')
+                  )}`}
+                  width={40}
+                  height={60}
+                />
               )}
               {provided.placeholder}
             </div>

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import streamlit as st
 from streamlit_lottie import st_lottie
+import time
 
 # When this file is executed by Streamlit the module is run as a script and
 # not as part of a package. Relative imports therefore fail because
@@ -37,6 +38,17 @@ with st.expander("Nueva partida", expanded=False):
     rounds = st.slider("Rondas", 1, 8, 8, key="rounds_setup")
     start = st.button("Iniciar")
 
+with st.sidebar.expander("Reglas del juego", expanded=False):
+    st.markdown(
+        """
+        - Roba cartas del mazo o pozo en tu turno.
+        - Forma tríos o escaleras para bajar tus cartas.
+        - Cuando estés listo, descarta y cierra la ronda.
+        """
+    )
+
+st.sidebar.toggle("Auto-refrescar puntaje", key="auto_refresh_scores")
+
 if "game" not in st.session_state or start:
     st.session_state.game = GameState.new(players, rounds)
 st.markdown("[Reglas](https://example.com/reglas.pdf)")
@@ -51,11 +63,22 @@ game: GameState = st.session_state.game
 
 st.title(f"Carioca – Ronda {game.round.number}")
 
-scores_data = [
-    {"Jugador": f"➡️ {i+1}" if i == game.current_player else i + 1, "Puntaje": s}
-    for i, s in enumerate(game.scores)
-]
-st.table(scores_data)
+scores_placeholder = st.empty()
+
+
+def render_scores() -> None:
+    scores_data = [
+        {"Jugador": f"➡️ {i+1}" if i == game.current_player else i + 1, "Puntaje": s}
+        for i, s in enumerate(game.scores)
+    ]
+    scores_placeholder.table(scores_data)
+
+
+render_scores()
+
+if st.session_state.get("auto_refresh_scores"):
+    time.sleep(5)
+    st.experimental_rerun()
 
 if st.session_state.pop("show_balloons", False):
     st.balloons()


### PR DESCRIPTION
## Summary
- animate draggable cards with framer-motion
- add optional score auto-refresh and help sidebar

## Testing
- `pytest -q`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885b4458e74832884fc14840ad7e7c4