### PR TITLE
Improve gameboard UI

### DIFF
--- a/frontend/src/GameBoard.css
+++ b/frontend/src/GameBoard.css
@@ -1,0 +1,68 @@
+.board {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  font-family: sans-serif;
+}
+
+.scoreboard {
+  display: flex;
+  gap: 1rem;
+}
+
+.score {
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  background: #eee;
+}
+
+.currentPlayer {
+  background: #cdeaff;
+  font-weight: bold;
+}
+
+.zoneRow {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.pile {
+  width: 60px;
+  height: 90px;
+  border: 1px solid #444;
+  border-radius: 4px;
+  background: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.table {
+  min-height: 100px;
+  min-width: 200px;
+  border: 1px dashed #666;
+  border-radius: 4px;
+  padding: 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.meld {
+  display: flex;
+  gap: 0.25rem;
+  margin-right: 0.5rem;
+}
+
+.playerHand {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.card {
+  width: 60px;
+  height: 90px;
+}

--- a/frontend/src/GameBoard.test.tsx
+++ b/frontend/src/GameBoard.test.tsx
@@ -18,4 +18,17 @@ describe('GameBoard', () => {
     const { getByRole } = render(<GameBoard state={state} onMove={onMove} />);
     expect(getByRole('img')).toBeTruthy();
   });
+
+  it('renders scoreboard', () => {
+    const onMove = vi.fn();
+    const { getByText } = render(<GameBoard state={state} onMove={onMove} />);
+    expect(getByText('Player 1')).toBeTruthy();
+  });
+
+  it('emits draw event when clicking stock', () => {
+    const onMove = vi.fn();
+    const { getByLabelText } = render(<GameBoard state={state} onMove={onMove} />);
+    fireEvent.click(getByLabelText('stock'));
+    expect(onMove).toHaveBeenCalledWith({ type: 'draw', data: { from: 'stock' } });
+  });
 });

--- a/frontend/src/GameBoard.tsx
+++ b/frontend/src/GameBoard.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { motion } from 'framer-motion';
-import { Card, GameState, MovePayload } from './types';
+import { Card, GameState, MovePayload, Zone } from './types';
 import { useDrag } from './hooks/useDrag';
+import './GameBoard.css';
 
 export interface GameBoardProps {
   state: GameState;
@@ -16,69 +17,65 @@ export function GameBoard({ state, onMove }: GameBoardProps) {
     onDragEnd();
     if (!result.destination) return;
     const cardId = result.draggableId;
-    onMove({
-      type: 'move',
-      data: {
-        card_ids: [cardId],
-        source_zone: result.source.droppableId,
-        target_zone: result.destination.droppableId,
-      },
-    });
+    const target = result.destination.droppableId as Zone;
+
+    if (target === 'discard') {
+      onMove({ type: 'discard', data: { card_id: cardId } });
+      return;
+    }
+    if (target === 'table_meld') {
+      onMove({ type: 'lay', data: { card_ids: [cardId] } });
+      return;
+    }
+    if (target !== result.source.droppableId) {
+      onMove({
+        type: 'move',
+        data: {
+          card_ids: [cardId],
+          source_zone: result.source.droppableId,
+          target_zone: target,
+        },
+      });
+    }
+  }
+
+  function draw(from: Zone) {
+    onMove({ type: 'draw', data: { from } });
   }
 
   return (
-    <DragDropContext onDragEnd={handleDragEnd} onDragStart={(e) => onDragStart(e.source)}>
-      <div style={{ display: 'flex', flexDirection: 'row', gap: '1rem' }}>
-        <Droppable droppableId="player_hand" direction="horizontal">
-          {(provided, snapshot) => (
-            <div
-              ref={provided.innerRef}
-              {...provided.droppableProps}
-              style={{
-                display: 'flex',
-                background: snapshot.isDraggingOver ? '#f0f0f0' : 'transparent',
-                transition: 'background 0.2s ease',
-              }}
-            >
-              {state.players[0].hand.map((c: Card, idx: number) => (
-                <Draggable draggableId={`${idx}`} index={idx} key={idx}>
-                  {(prov, snap) => (
-                    <motion.img
-                      ref={prov.innerRef}
-                      {...prov.draggableProps}
-                      {...prov.dragHandleProps}
-                      src={`data:image/svg+xml;base64,${btoa(c.rank + (c.suit || ''))}`}
-                      width={40}
-                      height={60}
-                      animate={{
-                        rotate: snap.isDragging ? 5 : 0,
-                        scale: snap.isDragging ? 1.1 : 1,
-                      }}
-                      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
-                      style={{
-                        boxShadow: snap.isDragging
-                          ? '0 4px 8px rgba(0,0,0,0.3)'
-                          : 'none',
-                      }}
-                    />
-                  )}
-                </Draggable>
-              ))}
-              {provided.placeholder}
-            </div>
-          )}
-        </Droppable>
+    <div className="board">
+      <div className="scoreboard">
+        {state.players.map((p, i) => (
+          <div
+            key={p.id}
+            className={`score ${i === state.current_turn ? 'currentPlayer' : ''}`}
+          >
+            {p.name ?? `Player ${i + 1}`}
+          </div>
+        ))}
+      </div>
+
+      <div className="zoneRow">
+        <div
+          className="pile"
+          role="button"
+          aria-label="stock"
+          onClick={() => draw('stock')}
+        >
+          {state.stock_count}
+        </div>
+
         <Droppable droppableId="discard">
           {(provided, snapshot) => (
             <div
               ref={provided.innerRef}
               {...provided.droppableProps}
+              className="pile"
+              aria-label="discard"
+              onClick={() => draw('discard')}
               style={{
-                width: 40,
-                height: 60,
-                border: '1px solid black',
-                background: snapshot.isDraggingOver ? '#f0f0f0' : 'transparent',
-                transition: 'background 0.2s ease',
+                background: snapshot.isDraggingOver ? '#f0f0f0' : undefined,
               }}
             >
               {state.discard_top && (
@@ -94,7 +91,72 @@ export function GameBoard({ state, onMove }: GameBoardProps) {
             </div>
           )}
         </Droppable>
+
+        <Droppable droppableId="table_meld" direction="horizontal">
+          {(provided, snapshot) => (
+            <div
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              className="table"
+              aria-label="table"
+              style={{
+                background: snapshot.isDraggingOver ? '#f9f9f9' : undefined,
+              }}
+            >
+              {state.table_melds.map((meld, mi) => (
+                <div key={mi} className="meld">
+                  {meld.cards.map((c, ci) => (
+                    <img
+                      key={ci}
+                      src={`data:image/svg+xml;base64,${btoa(c.rank + (c.suit || ''))}`}
+                      width={40}
+                      height={60}
+                    />
+                  ))}
+                </div>
+              ))}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
       </div>
-    </DragDropContext>
+
+      <DragDropContext onDragEnd={handleDragEnd} onDragStart={(e) => onDragStart(e.source)}>
+        <Droppable droppableId="player_hand" direction="horizontal">
+          {(provided, snapshot) => (
+            <div
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              className="playerHand"
+              style={{
+                background: snapshot.isDraggingOver ? '#f0f0f0' : undefined,
+              }}
+            >
+              {state.players[0].hand.map((c: Card, idx: number) => (
+                <Draggable draggableId={`${idx}`} index={idx} key={idx}>
+                  {(prov, snap) => (
+                    <motion.img
+                      ref={prov.innerRef}
+                      {...prov.draggableProps}
+                      {...prov.dragHandleProps}
+                      src={`data:image/svg+xml;base64,${btoa(c.rank + (c.suit || ''))}`}
+                      width={60}
+                      height={90}
+                      animate={{
+                        rotate: snap.isDragging ? 5 : 0,
+                        scale: snap.isDragging ? 1.1 : 1,
+                      }}
+                      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+                      className="card"
+                    />
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </div>
+          )}
+        </Droppable>
+      </DragDropContext>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- revamp the React game board UI
- add a CSS stylesheet for a cleaner layout
- expand unit tests for the new board

## Testing
- `npm test` *(fails: vitest not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6885b5c9c2f48328ab4812001391db72