### PR TITLE
Improve card and table styling

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -71,7 +71,11 @@ def render_scores() -> None:
         {"Jugador": f"➡️ {i+1}" if i == game.current_player else i + 1, "Puntaje": s}
         for i, s in enumerate(game.scores)
     ]
-    scores_placeholder.table(scores_data)
+    scores_placeholder.dataframe(
+        scores_data,
+        hide_index=True,
+        use_container_width=True,
+    )
 
 
 render_scores()

--- a/streamlit_app/templates/card_back.svg
+++ b/streamlit_app/templates/card_back.svg
@@ -1,4 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="160" height="240" viewBox="0 0 160 240" aria-label="Card back">
-  <rect width="160" height="240" rx="12" fill="#361860"/>
+  <defs>
+    <linearGradient id="backGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#361860"/>
+      <stop offset="100%" stop-color="#5f1bb4"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="240" rx="12" fill="url(#backGrad)"/>
+  <rect x="10" y="10" width="140" height="220" rx="10" fill="none" stroke="#F1AC4B" stroke-width="4"/>
   <text x="80" y="120" font-size="40" fill="#F1AC4B" text-anchor="middle" dominant-baseline="middle">Carioca</text>
 </svg>

--- a/streamlit_app/templates/card_front.svg
+++ b/streamlit_app/templates/card_front.svg
@@ -1,4 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="160" height="240" viewBox="0 0 160 240" aria-label="{{ rank }}{{ suit }} card">
-  <rect width="160" height="240" rx="12" fill="#fff" stroke="#000"/>
-  <text x="80" y="120" font-size="60" text-anchor="middle" dominant-baseline="middle">{{ rank }}{{ suit }}</text>
+  <defs>
+    <linearGradient id="frontGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff"/>
+      <stop offset="100%" stop-color="#eee"/>
+    </linearGradient>
+  </defs>
+  <rect width="160" height="240" rx="12" fill="url(#frontGrad)" stroke="#000" stroke-width="2"/>
+  <text x="20" y="30" font-size="24">{{ rank }}</text>
+  <text x="140" y="210" font-size="24" transform="rotate(180 140 210)">{{ rank }}</text>
+  <text x="80" y="120" font-size="60" text-anchor="middle" dominant-baseline="middle">{{ suit }}</text>
 </svg>


### PR DESCRIPTION
## Summary
- restyle front/back card templates with gradients and borders
- display the score table using `st.dataframe` for a sleeker look

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_6885b608ec648328b8240f06710e3b6a