### PR TITLE
Improve gameboard UI

### DIFF
--- a/frontend/src/GameBoard.css
+++ b/frontend/src/GameBoard.css
@@ -6,15 +6,18 @@
   font-family: sans-serif;
 }
 
+
 .scoreboard {
   display: flex;
   gap: 1rem;
+  margin-bottom: 0.5rem;
 }
 
 .score {
-  padding: 0.2rem 0.5rem;
-  border-radius: 4px;
+  padding: 0.25rem 0.75rem;
+  border-radius: 8px;
   background: #eee;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
 .currentPlayer {

--- a/frontend/src/GameBoard.test.tsx
+++ b/frontend/src/GameBoard.test.tsx
@@ -22,7 +22,7 @@ describe('GameBoard', () => {
   it('renders scoreboard', () => {
     const onMove = vi.fn();
     const { getByText } = render(<GameBoard state={state} onMove={onMove} />);
-    expect(getByText('Player 1')).toBeTruthy();
+    expect(getByText('Player 1 (1)')).toBeTruthy();
   });
 
   it('emits draw event when clicking stock', () => {
@@ -30,5 +30,12 @@ describe('GameBoard', () => {
     const { getByLabelText } = render(<GameBoard state={state} onMove={onMove} />);
     fireEvent.click(getByLabelText('stock'));
     expect(onMove).toHaveBeenCalledWith({ type: 'draw', data: { from: 'stock' } });
+  });
+
+  it('emits draw event when double clicking discard', () => {
+    const onMove = vi.fn();
+    const { getByLabelText } = render(<GameBoard state={state} onMove={onMove} />);
+    fireEvent.dblClick(getByLabelText('discard'));
+    expect(onMove).toHaveBeenCalledWith({ type: 'draw', data: { from: 'discard' } });
   });
 });

--- a/frontend/src/GameBoard.tsx
+++ b/frontend/src/GameBoard.tsx
@@ -19,6 +19,18 @@ export function GameBoard({ state, onMove }: GameBoardProps) {
     const cardId = result.draggableId;
     const target = result.destination.droppableId as Zone;
 
+    if (
+      result.source.droppableId === 'player_hand' &&
+      result.destination.droppableId === 'player_hand' &&
+      result.destination.index !== result.source.index
+    ) {
+      onMove({
+        type: 'reorder',
+        data: { from: result.source.index, to: result.destination.index },
+      });
+      return;
+    }
+
     if (target === 'discard') {
       onMove({ type: 'discard', data: { card_id: cardId } });
       return;
@@ -51,7 +63,7 @@ export function GameBoard({ state, onMove }: GameBoardProps) {
             key={p.id}
             className={`score ${i === state.current_turn ? 'currentPlayer' : ''}`}
           >
-            {p.name ?? `Player ${i + 1}`}
+            {p.name ?? `Player ${i + 1}`} ({p.hand.length})
           </div>
         ))}
       </div>
@@ -62,6 +74,7 @@ export function GameBoard({ state, onMove }: GameBoardProps) {
           role="button"
           aria-label="stock"
           onClick={() => draw('stock')}
+          onDoubleClick={() => draw('stock')}
         >
           {state.stock_count}
         </div>
@@ -74,6 +87,7 @@ export function GameBoard({ state, onMove }: GameBoardProps) {
               className="pile"
               aria-label="discard"
               onClick={() => draw('discard')}
+              onDoubleClick={() => draw('discard')}
               style={{
                 background: snapshot.isDraggingOver ? '#f0f0f0' : undefined,
               }}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -21,7 +21,12 @@ export interface GameState {
   phase: 'draw' | 'play' | 'end';
 }
 
+export interface ReorderData {
+  from: number;
+  to: number;
+}
+
 export interface MovePayload {
-  type: 'move' | 'draw' | 'discard' | 'lay' | 'end_turn';
+  type: 'move' | 'draw' | 'discard' | 'lay' | 'end_turn' | 'reorder';
   data: any;
 }


### PR DESCRIPTION
## Summary
- update event types with `reorder` action
- add card count and double-click draw on the GameBoard
- style scoreboard with subtle drop shadow
- test for updated scoreboard and double-click behaviour

## Testing
- `pytest -q`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885b729292c832886868cf5d108d2fa