### PR TITLE
Improve Carioca interface

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -38,7 +38,7 @@ with st.expander("Nueva partida", expanded=False):
     rounds = st.slider("Rondas", 1, 8, 8, key="rounds_setup")
     start = st.button("Iniciar")
 
-with st.sidebar.expander("Reglas del juego", expanded=False):
+with st.expander("Reglas y opciones", expanded=False):
     st.markdown(
         """
         - Roba cartas del mazo o pozo en tu turno.
@@ -46,12 +46,11 @@ with st.sidebar.expander("Reglas del juego", expanded=False):
         - Cuando estés listo, descarta y cierra la ronda.
         """
     )
-
-st.sidebar.toggle("Auto-refrescar puntaje", key="auto_refresh_scores")
+    st.markdown("[Reglamento completo](https://example.com/reglas.pdf)")
+    st.toggle("Auto-refrescar puntaje", key="auto_refresh_scores")
 
 if "game" not in st.session_state or start:
     st.session_state.game = GameState.new(players, rounds)
-st.markdown("[Reglas](https://example.com/reglas.pdf)")
 
 # -------------------------------------------------------------------
 # Main Header – title and scoreboard
@@ -62,7 +61,7 @@ if "game" not in st.session_state:
 game: GameState = st.session_state.game
 
 st.title(f"Carioca – Ronda {game.round.number}")
-
+st.subheader("Puntajes")
 scores_placeholder = st.empty()
 
 
@@ -71,11 +70,7 @@ def render_scores() -> None:
         {"Jugador": f"➡️ {i+1}" if i == game.current_player else i + 1, "Puntaje": s}
         for i, s in enumerate(game.scores)
     ]
-    scores_placeholder.dataframe(
-        scores_data,
-        hide_index=True,
-        use_container_width=True,
-    )
+    scores_placeholder.table(scores_data)
 
 
 render_scores()
@@ -123,13 +118,14 @@ for i, card in enumerate(game.hand):
 selected.sort()
 st.session_state.sel_cards = selected
 
-if st.button("Descartar", key="discard_btn") and selected:
+act_col1, act_col2 = st.columns(2)
+if act_col1.button("Descartar", key="discard_btn", disabled=not selected):
     game.discard(selected[0])
     game.next_player()
     st.session_state.clear_sel_cards = True
     st.experimental_rerun()
 
-if st.button("Formar trío/escala", key="meld_btn") and selected:
+if act_col2.button("Formar trío/escala", key="meld_btn", disabled=not selected):
     if game.meld(selected):
         st.success("Combinación válida")
     else:

--- a/streamlit_app/templates/card_front.svg
+++ b/streamlit_app/templates/card_front.svg
@@ -6,7 +6,7 @@
     </linearGradient>
   </defs>
   <rect width="160" height="240" rx="12" fill="url(#frontGrad)" stroke="#000" stroke-width="2"/>
-  <text x="20" y="30" font-size="24">{{ rank }}</text>
-  <text x="140" y="210" font-size="24" transform="rotate(180 140 210)">{{ rank }}</text>
-  <text x="80" y="120" font-size="60" text-anchor="middle" dominant-baseline="middle">{{ suit }}</text>
+  <text x="20" y="30" font-size="24" fill="{{ color }}">{{ rank }}</text>
+  <text x="140" y="210" font-size="24" transform="rotate(180 140 210)" fill="{{ color }}">{{ rank }}</text>
+  <text x="80" y="120" font-size="60" text-anchor="middle" dominant-baseline="middle" fill="{{ color }}">{{ suit }}</text>
 </svg>

--- a/streamlit_app/utils.py
+++ b/streamlit_app/utils.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError:  # pragma: no cover - allow tests without deps
     Environment = None  # type: ignore
     FileSystemLoader = None  # type: ignore
 
-from carioca.cards import Card, JOKER
+from carioca.cards import Card, JOKER, Suit
 
 if Environment:
     TEMPLATES = Environment(loader=FileSystemLoader(Path(__file__).parent / "templates"))
@@ -31,7 +31,8 @@ def card_svg(card: Optional[Card] = None, *, back: bool = False) -> str:
         else:
             rank = card.rank if card.rank != JOKER else "🃏"
             suit = card.suit.value if card.suit else ""
+            color = "#d00" if card.suit in (Suit.HEARTS, Suit.DIAMONDS) else "#000"
             tpl = TEMPLATES.get_template("card_front.svg")
-            svg = tpl.render(rank=rank, suit=suit)
+            svg = tpl.render(rank=rank, suit=suit, color=color)
     data = base64.b64encode(svg.encode()).decode()
     return f"data:image/svg+xml;base64,{data}"


### PR DESCRIPTION
## Summary
- color hearts and diamonds red
- inline rules and options in page instead of sidebar
- show scoreboard in a table
- align discard and meld buttons side by side

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b79e683483289af0e2710e03e556