### PR TITLE
Add interactive board component

### DIFF
--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import streamlit as st
-from streamlit_lottie import st_lottie
 import time
 
 # When this file is executed by Streamlit the module is run as a script and
@@ -21,8 +20,9 @@ repo_root = os.path.abspath(os.path.join(current_dir, os.pardir))
 if repo_root not in sys.path:
     sys.path.insert(0, repo_root)
 
-from state import GameState
-from utils import card_svg
+from state import GameState  # noqa: E402
+from python.carioca_component import carioca_component  # noqa: E402
+from board_adapter import to_component_state, apply_move  # noqa: E402
 
 st.set_page_config(page_title="Carioca", page_icon="🃏", layout="wide")
 
@@ -87,50 +87,11 @@ if "round_msg" in st.session_state:
 # -------------------------------------------------------------------
 # Board area – player's hand and piles
 # -------------------------------------------------------------------
-col_deck, col_discard = st.columns(2)
-if col_deck.button("Robar mazo", key="draw_deck", help="D", use_container_width=True):
-    game.draw(from_discard=False)
-if col_discard.button(
-    f"Robar pozo ({len(game.round.discard_pile)})",
-    key="draw_discard",
-    help="P",
-    use_container_width=True,
-):
-    game.draw(from_discard=True)
-
-st.subheader("Tu mano")
-# Clear previous selection before rendering widget
-if st.session_state.get("clear_sel_cards"):
-    if "sel_cards" in st.session_state:
-        st.session_state.sel_cards = []
-    st.session_state.clear_sel_cards = False
-
-selected = st.session_state.get("sel_cards", [])
-cols = st.columns(len(game.hand))
-for i, card in enumerate(game.hand):
-    with cols[i]:
-        st.image(card_svg(card), use_column_width=True)
-        chosen = st.toggle("", key=f"card_{i}", value=i in selected)
-        if chosen and i not in selected:
-            selected.append(i)
-        if not chosen and i in selected:
-            selected.remove(i)
-selected.sort()
-st.session_state.sel_cards = selected
-
-act_col1, act_col2 = st.columns(2)
-if act_col1.button("Descartar", key="discard_btn", disabled=not selected):
-    game.discard(selected[0])
-    game.next_player()
-    st.session_state.clear_sel_cards = True
+state_dict = to_component_state(game)
+payload = carioca_component(state_dict, key="board")
+if isinstance(payload, dict) and payload.get("type"):
+    apply_move(game, payload)
     st.experimental_rerun()
-
-if act_col2.button("Formar trío/escala", key="meld_btn", disabled=not selected):
-    if game.meld(selected):
-        st.success("Combinación válida")
-    else:
-        st.error("No es trío ni escala")
-    st.session_state.clear_sel_cards = True
 
 # -------------------------------------------------------------------
 # Meld area

--- a/streamlit_app/board_adapter.py
+++ b/streamlit_app/board_adapter.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from carioca.gamestate import GameState
+from carioca.cards import Card
+from carioca.hand import Hand
+
+__all__ = ["to_component_state", "apply_move"]
+
+
+def _card_to_dict(card: Card) -> Dict[str, Any]:
+    return {"rank": card.rank, "suit": card.suit.value if card.suit else None}
+
+
+def to_component_state(game: GameState) -> Dict[str, Any]:
+    """Convert :class:`GameState` to the frontend representation."""
+
+    players = [
+        {"id": i, "hand": [_card_to_dict(c) for c in hand]}
+        for i, hand in enumerate(game.round.hands)
+    ]
+    table_melds: List[Dict[str, Any]] = []
+    for owner, melds in game.melds.items():
+        for meld in melds:
+            table_melds.append(
+                {"owner": owner, "cards": [_card_to_dict(c) for c in meld]}
+            )
+
+    discard_top = (
+        _card_to_dict(game.round.discard_pile[-1])
+        if game.round.discard_pile
+        else None
+    )
+    return {
+        "players": players,
+        "table_melds": table_melds,
+        "discard_top": discard_top,
+        "stock_count": len(game.round.draw_pile),
+        "current_turn": game.current_player,
+        "phase": "play",
+    }
+
+
+def apply_move(game: GameState, payload: Dict[str, Any]) -> None:
+    """Apply a move payload returned by the frontend component."""
+
+    move_type = payload.get("type")
+    data = payload.get("data", {})
+
+    if move_type == "draw":
+        source = data.get("from")
+        game.draw(from_discard=source == "discard")
+
+    elif move_type == "discard":
+        idx = int(data.get("card_id", 0))
+        game.discard(idx)
+        game.next_player()
+
+    elif move_type == "lay":
+        ids = [int(i) for i in data.get("card_ids", [])]
+        game.meld(ids)
+
+    elif move_type == "reorder":
+        start = int(data.get("from", 0))
+        end = int(data.get("to", 0))
+        hand: Hand = game.hand
+        card = hand.pop(start)
+        hand.insert(end, card)
+
+    elif move_type == "move":
+        # Not yet implemented - ignore for now
+        pass
+

--- a/tests/test_board_adapter.py
+++ b/tests/test_board_adapter.py
@@ -1,0 +1,41 @@
+from streamlit_app.board_adapter import to_component_state, apply_move
+from carioca.gamestate import GameState
+from carioca.cards import Card, Suit
+from carioca.hand import Hand
+
+
+def test_to_component_state_keys() -> None:
+    game = GameState.new(players=2)
+    state = to_component_state(game)
+    assert state["current_turn"] == game.current_player
+    assert state["stock_count"] == len(game.round.draw_pile)
+    assert len(state["players"]) == 2
+
+
+def test_apply_move_draw_discard() -> None:
+    game = GameState.new(players=2)
+    initial = len(game.hand)
+    apply_move(game, {"type": "draw", "data": {"from": "stock"}})
+    assert len(game.hand) == initial + 1
+    apply_move(game, {"type": "discard", "data": {"card_id": 0}})
+    assert len(game.round.discard_pile) == 2
+
+
+def test_apply_move_reorder() -> None:
+    game = GameState.new(players=1)
+    game.round.hands[0] = Hand([Card("3", Suit.SPADES), Card("4", Suit.SPADES)])
+    apply_move(game, {"type": "reorder", "data": {"from": 0, "to": 1}})
+    assert game.round.hands[0][1].rank == "3"
+
+
+def test_apply_move_lay_trio() -> None:
+    game = GameState.new(players=1)
+    game.round.hands[0] = Hand([
+        Card("2", Suit.CLUBS),
+        Card("2", Suit.DIAMONDS),
+        Card("2", Suit.HEARTS),
+    ])
+    apply_move(game, {"type": "lay", "data": {"card_ids": [0, 1, 2]}})
+    assert len(game.round.hands[0]) == 0
+    assert game.melds[0]
+


### PR DESCRIPTION
## Summary
- integrate the React board as a Streamlit component
- convert `GameState` to/from the component format
- update the Streamlit app to use the new interactive board
- add tests for the adapter helpers

## Testing
- `ruff check streamlit_app/app.py`
- `ruff check streamlit_app/board_adapter.py`
- `ruff check tests/test_board_adapter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885b94dc3c88328abb2d7f6b161643b