### PR TITLE
Add AI helper and stub websocket backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,24 @@ Launch the Streamlit UI:
 poetry run streamlit run streamlit_app/app.py
 ```
 
+### Multiplayer backend (experimental)
+
+An optional FastAPI server provides simple WebSocket rooms used to
+synchronise state between browser clients. Start it locally with:
+
+```bash
+python backend/main.py
+```
+
+The Streamlit app can connect using `st.experimental_connection` and the
+WebSocket URL `ws://localhost:8000/ws/<room>`.
+
 ## Features
 * Full game engine with flexible YAML rules.
 * Rich-styled Typer CLI.
 * ≥90 % test coverage goal (pytest + coverage).
 * Docker & GitHub Actions CI.
+* Experimental AI helpers for automated opponents.
 
 See `docs/` soon for detailed rules.
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,54 @@
+"""Minimal FastAPI WebSocket backend for Carioca."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List
+
+try:  # Optional dependency
+    from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+except ModuleNotFoundError:  # pragma: no cover - environment without fastapi
+    FastAPI = None  # type: ignore
+    WebSocket = object  # type: ignore
+    class WebSocketDisconnect(Exception):
+        pass
+
+
+class ConnectionManager:
+    """Keep track of active WebSocket connections per room."""
+
+    def __init__(self) -> None:
+        self.rooms: Dict[str, List[WebSocket]] = defaultdict(list)
+
+    async def connect(self, room: str, websocket: WebSocket) -> None:
+        await websocket.accept()
+        self.rooms[room].append(websocket)
+
+    def disconnect(self, room: str, websocket: WebSocket) -> None:
+        if room in self.rooms and websocket in self.rooms[room]:
+            self.rooms[room].remove(websocket)
+
+    async def broadcast(self, room: str, message: str) -> None:
+        for ws in list(self.rooms.get(room, [])):
+            await ws.send_text(message)
+
+
+manager = ConnectionManager()
+app = FastAPI() if FastAPI else None
+
+if app:
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.websocket("/ws/{room}")
+    async def websocket_endpoint(websocket: WebSocket, room: str) -> None:
+        await manager.connect(room, websocket)
+        try:
+            while True:
+                data = await websocket.receive_text()
+                await manager.broadcast(room, data)
+        except WebSocketDisconnect:
+            manager.disconnect(room, websocket)
+

--- a/carioca/ai/__init__.py
+++ b/carioca/ai/__init__.py
@@ -1,0 +1,19 @@
+"""Basic AI helpers for Carioca."""
+
+from __future__ import annotations
+from typing import Sequence
+from ..cards import Card
+
+__all__ = ["choose_discard"]
+
+
+def choose_discard(hand: Sequence[Card]) -> int:
+    """Return index of card to discard from *hand*.
+
+    This naive strategy discards the highest value card.
+    """
+    if not hand:
+        return -1
+    idx, _ = max(enumerate(hand), key=lambda pair: pair[1].value)
+    return idx
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,8 @@ services:
     build: .
     image: carioca:latest
     tty: true
+  backend:
+    build: .
+    command: python backend/main.py
+    ports:
+      - "8000:8000"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ streamlit = "^1.35"
 jinja2 = "^3.1"
 pydantic = "^2.7"
 streamlit-lottie = "^0.0.5"
+fastapi = {version = "^0.111", optional = true}
+uvicorn = {version = "^0.29", optional = true}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
@@ -22,6 +24,7 @@ pytest-cov = "^5.0"
 ruff = "^0.4.8"
 black = "^24.3.0"
 mypy = "^1.10.0"
+pytest-asyncio = "^0.23"
 
 [tool.poetry.scripts]
 carioca = "carioca.cli:app"

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,9 @@
+from carioca.ai import choose_discard
+from carioca.cards import Card, Suit
+from carioca.hand import Hand
+
+
+def test_choose_discard() -> None:
+    hand = Hand([Card("2", Suit.CLUBS), Card("K", Suit.HEARTS)])
+    assert choose_discard(hand) == 1
+


### PR DESCRIPTION
## Summary
- add an experimental FastAPI websocket backend with room based broadcast
- provide basic AI helper to choose a discard
- document new backend and AI in README
- extend poetry dependencies and docker compose for the backend
- test the simple AI logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885ba7900808328a5c09ed04fbf49f0