### PR TITLE
Add FastAPI backend with basic WebSocket rooms

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ Run the example app:
 ```bash
 poetry run streamlit run example_app.py
 ```
+
+## Backend API
+
+A minimal FastAPI server provides WebSocket rooms for multiplayer experiments.
+
+```bash
+poetry run uvicorn backend.app:app --reload
+```
+
+Connect clients to `ws://localhost:8000/ws/{room_id}` and broadcast game
+messages as JSON.

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI(title="Carioca Backend")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+rooms: dict[str, set[WebSocket]] = {}
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    """Healthcheck endpoint."""
+    return {"status": "ok"}
+
+
+@app.websocket("/ws/{room_id}")
+async def websocket_endpoint(ws: WebSocket, room_id: str) -> None:
+    await ws.accept()
+    connections = rooms.setdefault(room_id, set())
+    connections.add(ws)
+    try:
+        while True:
+            data = await ws.receive_json()
+            for conn in list(connections):
+                if conn is not ws:
+                    await conn.send_json(data)
+    except WebSocketDisconnect:
+        connections.remove(ws)
+        if not connections:
+            rooms.pop(room_id, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,16 @@ streamlit = "^1.35"
 jinja2 = "^3.1"
 pydantic = "^2.7"
 streamlit-lottie = "^0.0.5"
+fastapi = "^0.111"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0"
 pytest-cov = "^5.0"
+pytest-asyncio = "^0.23"
 ruff = "^0.4.8"
 black = "^24.3.0"
 mypy = "^1.10.0"
+uvicorn = { version = "^0.29.0", optional = true }
 
 [tool.poetry.scripts]
 carioca = "carioca.cli:app"

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from backend.app import app
+
+
+def test_ws_broadcast() -> None:
+    client = TestClient(app)
+    with client.websocket_connect("/ws/room") as a, client.websocket_connect("/ws/room") as b:
+        a.send_json({"msg": "hi"})
+        data = b.receive_json()
+        assert data == {"msg": "hi"}
+


### PR DESCRIPTION
## Summary
- add `backend` FastAPI app with websocket room broadcast
- document backend server usage in README
- include simple websocket broadcast test
- extend poetry config with FastAPI and related dev deps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6885bac6eea8832885f734cde6e86125